### PR TITLE
Example fixes

### DIFF
--- a/bpfctl/src/main.rs
+++ b/bpfctl/src/main.rs
@@ -399,10 +399,12 @@ impl ProgTable {
             }
         }
 
-        table.add_row(vec![
-            "Map Pin Path:",
-            &r.map_pin_path.is_empty().then_some("None").unwrap(),
-        ]);
+        if r.map_pin_path.is_empty() {
+            table.add_row(vec!["Map Pin Path:", "None"]);
+        } else {
+            table.add_row(vec!["Map Pin Path:", &r.map_pin_path]);
+        }
+
         if r.map_owner_id.is_none() {
             table.add_row(vec!["Map Owner ID:", "None"]);
         } else {

--- a/bpfd/src/bpf.rs
+++ b/bpfd/src/bpf.rs
@@ -723,9 +723,15 @@ impl BpfManager {
 
                 match self.programs.get(&prog_id) {
                     Some(p) => {
-                        let map_used_by = self.get_map_used_by(prog_id, p.data().map_owner_id)?;
-                        p.clone().data_mut().map_used_by = Some(map_used_by);
-                        Ok(p.to_owned())
+                        let map_owner_id = p.data().map_owner_id;
+                        let map_used_by = self.get_map_used_by(prog_id, map_owner_id)?;
+                        match self.programs.get_mut(&prog_id) {
+                            Some(p_mut) => {
+                                p_mut.data_mut().map_used_by = Some(map_used_by);
+                                Ok(p_mut.to_owned())
+                            }
+                            None => Ok(Program::Unsupported(prog.try_into()?)),
+                        }
                     }
                     None => Ok(Program::Unsupported(prog.try_into()?)),
                 }

--- a/bpfd/src/rpc.rs
+++ b/bpfd/src/rpc.rs
@@ -339,6 +339,12 @@ impl Bpfd for BpfdLoader {
                                     }
                                 };
 
+                                // Copy map_pin_path if it is set.
+                                if let Some(map_pin_path) = r.data().map_pin_path.clone() {
+                                    reply_entry.map_pin_path =
+                                        map_pin_path.into_os_string().into_string().unwrap();
+                                };
+
                                 reply.results.push(reply_entry)
                             }
                         }

--- a/examples/go-tc-counter/main.go
+++ b/examples/go-tc-counter/main.go
@@ -88,16 +88,23 @@ func main() {
 		}
 		c := gobpfd.NewBpfdClient(conn)
 
-		mapOwnerId := uint32(paramData.MapOwnerId)
-
-		// If the bytecode src is a UUID, skip the loading and unloading of the bytecode.
-		if paramData.BytecodeSrc != configMgmt.SrcUuid {
-			loadRequestCommon := &gobpfd.LoadRequestCommon{
-				Location:    paramData.BytecodeSource.Location,
-				SectionName: "stats",
-				ProgramType: *bpfdHelpers.Tc.Uint32(),
-				Metadata:    map[string]string{configMgmt.UuidMetadataKey: paramData.Uuid},
-				MapOwnerId:  &mapOwnerId,
+		// If the bytecode src is a Program ID, skip the loading and unloading of the bytecode.
+		if paramData.BytecodeSrc != configMgmt.SrcProgId {
+			var loadRequestCommon *gobpfd.LoadRequestCommon
+			if paramData.MapOwnerId != 0 {
+				mapOwnerId := uint32(paramData.MapOwnerId)
+				loadRequestCommon = &gobpfd.LoadRequestCommon{
+					Location:    paramData.BytecodeSource.Location,
+					SectionName: "stats",
+					ProgramType: *bpfdHelpers.Tc.Uint32(),
+					MapOwnerId:  &mapOwnerId,
+				}
+			} else {
+				loadRequestCommon = &gobpfd.LoadRequestCommon{
+					Location:    paramData.BytecodeSource.Location,
+					SectionName: "stats",
+					ProgramType: *bpfdHelpers.Tc.Uint32(),
+				}
 			}
 
 			loadRequest := &gobpfd.LoadRequest{
@@ -119,30 +126,30 @@ func main() {
 				log.Print(err)
 				return
 			}
-			progId := res.GetId()
-			log.Printf("Program registered with %s id\n", paramData.Uuid)
+			paramData.ProgId = uint(res.GetId())
+			log.Printf("Program registered with id %d\n", paramData.ProgId)
 
 			// 2. Set up defer to unload program when this is closed
-			defer func(id string) {
-				log.Printf("Unloading Program: %s\n", id)
-				_, err = c.Unload(ctx, &gobpfd.UnloadRequest{Id: progId})
+			defer func(id uint) {
+				log.Printf("Unloading Program: %d\n", id)
+				_, err = c.Unload(ctx, &gobpfd.UnloadRequest{Id: uint32(id)})
 				if err != nil {
 					conn.Close()
 					log.Print(err)
 					return
 				}
 				conn.Close()
-			}(paramData.Uuid)
+			}(paramData.ProgId)
 		} else {
 			// 2. Set up defer to close connection
-			defer func(id string) {
-				log.Printf("Closing Connection for Program: %s\n", id)
+			defer func(id uint) {
+				log.Printf("Closing Connection for Program: %d\n", id)
 				conn.Close()
-			}(paramData.Uuid)
+			}(paramData.ProgId)
 		}
 
 		// 3. Get access to our map
-		mapPath, err = configMgmt.RetrieveMapPinPath(ctx, c, paramData, bpfdHelpers.Tc.Uint32(), "tc_stats_map")
+		mapPath, err = configMgmt.RetrieveMapPinPath(ctx, c, paramData.ProgId, bpfdHelpers.Tc.Uint32(), "tc_stats_map")
 		if err != nil {
 			log.Printf("Unable to retrieve maps\n")
 			conn.Close()


### PR DESCRIPTION
The example userspace programs were not running when started on host. This PR addresses these issues and allows the programs to run.

* map-pin-path was not being returned from bpfd.
* Once the data was returned, bpfctl barf'd on the value.
* map-used-by was not being returned from bpfd.
* Reworked the example code to allow Userspace to attach to an eBPF program that was already running via the Program ID (formally was done via a UUID).
* The existing examples called bpfd after a LoadRequest with a ListRequest, to obtain the map-pin-path of the just loaded eBPF program. This was replaced in earlier commits to filter the ListRequest based on the new Metadata Selectors. This wasn't working correctly, so it was backed out. A follow-up PR is planned to support a true GetRequest from bpfd, and all LoadResponses will include the GetResponse data. So the ListRequest logic will be gutted then anyway.